### PR TITLE
Bugfix/28 fix user cant comment at same post twice

### DIFF
--- a/src/MyLifeApp.Application/Interfaces/Repositories/IPostCommentRepository.cs
+++ b/src/MyLifeApp.Application/Interfaces/Repositories/IPostCommentRepository.cs
@@ -2,9 +2,8 @@ using MyLifeApp.Domain.Entities;
 
 namespace MyLifeApp.Application.Interfaces.Repositories
 {
-    public interface IPostCommentRepository : IGenericRepository<PostComment> 
-    { 
-        public Task<PostComment> CreatePostCommentAsync(PostComment postComment);
+    public interface IPostCommentRepository : IGenericRepository<PostComment>
+    {
         public Task<ICollection<PostComment>> GetAllCommentsFromPost(int postId);
         public Task<bool> PostCommentExistsAsync(int commentId);
     }

--- a/src/MyLifeApp.Application/Services/PostService.cs
+++ b/src/MyLifeApp.Application/Services/PostService.cs
@@ -43,6 +43,7 @@ namespace MyLifeApp.Application.Services
         }
 
         // TODO => add validation for private posts only for posts owners
+        //         1. if post is private, then just post author followers and post author can view the post,
         public async Task<DetailPostResponse> GetPostByIdAsync(int postId)
         {
             if (!await _postRepository.PostExistsAsync(postId))
@@ -266,12 +267,15 @@ namespace MyLifeApp.Application.Services
                 };
             }
 
-            Post post = await _postRepository.GetPostDetailsAsync(postId);
+            Post post = await _postRepository.GetByIdAsync(postId);
             Profile profile = await _authenticatedProfileService.GetAuthenticatedProfile();
 
-            PostComment comment = _mapper.Map<PostComment>(request);
-            comment.Profile = profile;
-            comment.Post = post;
+            PostComment comment = new()
+            {
+                ProfileId = profile.Id,
+                PostId = post.Id,
+                Comment = request.Comment
+            };
 
             await _postCommentRepository.CreateAsync(comment);
 

--- a/src/MyLifeApp.Domain/Common/BaseEntity.cs
+++ b/src/MyLifeApp.Domain/Common/BaseEntity.cs
@@ -1,7 +1,10 @@
-﻿namespace MyLifeApp.Domain.Common
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace MyLifeApp.Domain.Common
 {
     public abstract class BaseEntity
     {
+        [Key]
         public int Id { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }

--- a/src/MyLifeApp.Infrastructure.Data/Context/ApplicationDbContext.cs
+++ b/src/MyLifeApp.Infrastructure.Data/Context/ApplicationDbContext.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore;
-using Identity.Infrastructure.Models;
+﻿using Identity.Infrastructure.Models;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using MyLifeApp.Domain.Entities;
 
 namespace MyLifeApp.Infrastructure.Data.Context
@@ -40,23 +40,17 @@ namespace MyLifeApp.Infrastructure.Data.Context
 
             // Many-to-many: PostComment Entity
             builder.Entity<PostComment>()
-                .HasKey(pc => new { pc.PostId, pc.ProfileId });
+                .HasKey(pc => new { pc.Id });
             builder.Entity<PostComment>()
                 .HasOne(p => p.Post)
                 .WithMany(p => p.PostComments)
                 .HasForeignKey(p => p.PostId)
                 .OnDelete(DeleteBehavior.Restrict);
             builder.Entity<PostComment>()
-                .HasIndex(p => p.PostId)
-                .IsUnique(false);
-            builder.Entity<PostComment>()
-                .HasOne(p => p.Profile)
-                .WithMany(p => p.PostComments)
-                .HasForeignKey(p => p.ProfileId)
-                .OnDelete(DeleteBehavior.Restrict);
-            builder.Entity<PostComment>()
-                .HasIndex(p => p.ProfileId)
-                .IsUnique(false);
+               .HasOne(p => p.Profile)
+               .WithMany(p => p.PostComments)
+               .HasForeignKey(p => p.ProfileId)
+               .OnDelete(DeleteBehavior.Restrict);
 
             // Many-to-many: PostTags Entity
             builder.Entity<PostTag>()

--- a/src/MyLifeApp.Infrastructure.Data/Migrations/20230711140448_initial.Designer.cs
+++ b/src/MyLifeApp.Infrastructure.Data/Migrations/20230711140448_initial.Designer.cs
@@ -12,7 +12,7 @@ using MyLifeApp.Infrastructure.Data.Context;
 namespace MyLifeApp.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20230623192134_initial")]
+    [Migration("20230711140448_initial")]
     partial class initial
     {
         /// <inheritdoc />
@@ -297,11 +297,11 @@ namespace MyLifeApp.Infrastructure.Data.Migrations
 
             modelBuilder.Entity("MyLifeApp.Domain.Entities.PostComment", b =>
                 {
-                    b.Property<int>("PostId")
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    b.Property<int>("ProfileId")
-                        .HasColumnType("int");
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Comment")
                         .HasColumnType("nvarchar(max)");
@@ -309,13 +309,16 @@ namespace MyLifeApp.Infrastructure.Data.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
 
-                    b.Property<int>("Id")
+                    b.Property<int>("PostId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("ProfileId")
                         .HasColumnType("int");
 
                     b.Property<DateTime>("UpdatedAt")
                         .HasColumnType("datetime2");
 
-                    b.HasKey("PostId", "ProfileId");
+                    b.HasKey("Id");
 
                     b.HasIndex("PostId");
 

--- a/src/MyLifeApp.Infrastructure.Data/Migrations/20230711140448_initial.cs
+++ b/src/MyLifeApp.Infrastructure.Data/Migrations/20230711140448_initial.cs
@@ -279,10 +279,11 @@ namespace MyLifeApp.Infrastructure.Data.Migrations
                 name: "PostComments",
                 columns: table => new
                 {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
                     PostId = table.Column<int>(type: "int", nullable: false),
                     ProfileId = table.Column<int>(type: "int", nullable: false),
                     Comment = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    Id = table.Column<int>(type: "int", nullable: false),
                     CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
                     UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
                 },

--- a/src/MyLifeApp.Infrastructure.Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/MyLifeApp.Infrastructure.Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -294,11 +294,11 @@ namespace MyLifeApp.Infrastructure.Data.Migrations
 
             modelBuilder.Entity("MyLifeApp.Domain.Entities.PostComment", b =>
                 {
-                    b.Property<int>("PostId")
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    b.Property<int>("ProfileId")
-                        .HasColumnType("int");
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Comment")
                         .HasColumnType("nvarchar(max)");
@@ -306,13 +306,16 @@ namespace MyLifeApp.Infrastructure.Data.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
 
-                    b.Property<int>("Id")
+                    b.Property<int>("PostId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("ProfileId")
                         .HasColumnType("int");
 
                     b.Property<DateTime>("UpdatedAt")
                         .HasColumnType("datetime2");
 
-                    b.HasKey("PostId", "ProfileId");
+                    b.HasKey("Id");
 
                     b.HasIndex("PostId");
 

--- a/src/MyLifeApp.Infrastructure.Data/Repositories/PostCommentRepository.cs
+++ b/src/MyLifeApp.Infrastructure.Data/Repositories/PostCommentRepository.cs
@@ -16,13 +16,6 @@ namespace MyLifeApp.Infrastructure.Data.Repositories
             _postComments = context.Set<PostComment>();
         }
 
-        public async Task<PostComment> CreatePostCommentAsync(PostComment postComment)
-        {
-            await _context.AddAsync(postComment);
-            await _context.SaveChangesAsync();
-            return postComment;
-        }
-
         public async Task<ICollection<PostComment>> GetAllCommentsFromPost(int postId)
         {
             return await _postComments.Where(pc => pc.PostId == postId)


### PR DESCRIPTION
issue **#28** fixed!

PostComment is being mapped twice by context

for fix that I change the `CommentPostAsync` function (in PostService)

main changes:
`Post post = await _postRepository.GetByIdAsync(postId);`
